### PR TITLE
/auth/userdataと/users/profile/?id=idの追加

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -13,7 +13,7 @@ export class AuthController {
     }
 
     @UseGuards(AuthGuard)
-    @Get('profile')
+    @Get('userdata')
     getProfile(@Request() req:any) {
         return req.user;
     }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -19,6 +19,7 @@ export class AuthService {
         if (user?.password !== pass) {
             // throw new UnauthorizedException();
             throw new UnauthorizedException("パスワードとアカウントが一致しませんでした。");
+            // throw new Error("不一致");
         }
         const payload = { id: user.id, email: user.email };
         return {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { createAccountDTO } from 'src/dto/account.dto';
 
@@ -9,5 +9,10 @@ export class UsersController {
     @Post('/create')
     createAccount(@Body() createAccountDTO:createAccountDTO){
         return this.usersService.createAccount(createAccountDTO.name,createAccountDTO.email,createAccountDTO.password);
+    }
+
+    @Get('/profile')
+    getUserProfile(@Query('id') id:string){
+        return this.usersService.getUserProfile(Number(id));
     }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -47,4 +47,17 @@ export class UsersService {
         })
         return user;
     }
+
+    async getUserProfile(id:number){
+        const user = await this.prismaService.user.findUnique({
+            where: {id: id},
+            select: {
+                id: true,
+                name: true,
+                createdAt: true,
+                updatedAt: true
+            },
+        })
+        return user;
+    }
 }


### PR DESCRIPTION
## 実装した機能

例）いいね機能実装

- エンドポイントの修正
  - /auth/userdata
  - Get形式
  - リクエスト
    - トークンにアクセストークンを設定
  - レスポンス
    - /auth/profileと同じ
 エンドポイントを/auth/profileから/auth/userdataに書き直しました

- エンドポイントの作成
  - /users/profile/?id=id
  - Get形式
  - リクエスト
    - リクエストパラメータにid=number の形でidを指定
  - レスポンス
    - "id": number,
    - "name": string,
    - "createdAt": Date,
    - "updatedAt": "2024-07-15T01:32:45.542Z"
 エンドポイントを/auth/profileから/auth/userdataに書き直しました

